### PR TITLE
Add small GTA/Cityscapes 128x256 dataset configuration

### DIFF
--- a/datasets/gta_cityscapes/gta_cs_splits_small_first_cycle.py
+++ b/datasets/gta_cityscapes/gta_cs_splits_small_first_cycle.py
@@ -1,0 +1,176 @@
+import os.path
+import pickle
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+
+import numpy as np
+import pytorch_lightning as pl
+from sklearn.model_selection import KFold
+
+# This script mirrors ``gta_cs_splits_first_cycle.py`` and is provided for
+# convenience when working with the reduced 128x256 GTA/Cityscapes dataset.
+
+
+def main_cli():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--dataset_path",
+        "-d",
+        type=str,
+        help="Root path to the preprocessed GTA and Cityscapes dataset, i.e. path where the preprocessed "
+        "GTA and Cityscapes dataset are located in subfolders OriginalData/preprocessed and "
+        "CityScapesOriginalData/preprocessed respectively.",
+        required=True,
+    )
+    parser.add_argument(
+        "--original_dataset_path",
+        "-o",
+        type=str,
+        help="Root path to the original GTA and Cityscapes dataset, i.e. path where the original "
+        "GTA and Cityscapes dataset are located in subfolders OriginalData and "
+        "CityScapesOriginalData respectively. If not given, assumes the same folder as dataset_path",
+        default=None,
+    )
+    parser.add_argument(
+        "--splits_path",
+        "-s",
+        type=str,
+        help="Path to store the created splits file. "
+        "If not given, the will be stored in the dataset_path under splits/firstCycle/splits.pkl."
+        "If given as directory, a file named splits.pkl will be created, otherwise has to be specified as .pkl file",
+        default=None,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def get_cs_splits(base_dir: Path, split: str):
+    org_image_dir = (
+        base_dir / "CityScapesOriginalData" / "images" / "leftImg8bit" / split
+    )
+    split_dirs = [
+        path
+        for path in os.listdir(org_image_dir)
+        if os.path.isdir(os.path.join(org_image_dir, path))
+    ]
+    return sorted(split_dirs)
+
+
+def create_splits(
+    base_dir: Path, orig_base_dir: Path, splits_path: Path, seed, n_splits=5
+) -> None:
+    np.random.seed(seed)
+    gta_image_dir = base_dir / "OriginalData" / "preprocessed" / "images"
+    cs_image_dir = base_dir / "CityScapesOriginalData" / "preprocessed" / "images"
+
+    gta_images = [
+        (image, "gta")
+        for image in os.listdir(gta_image_dir)
+        if image.endswith(".npy") and not image.startswith("._")
+    ]
+    gta_images = sorted(gta_images)
+    print(len(gta_images))
+    cs_images = [
+        (image, "cs")
+        for image in os.listdir(cs_image_dir)
+        if image.endswith(".npy") and not image.startswith("._")
+    ]
+    cs_images = sorted(cs_images)
+    print(len(cs_images))
+
+    # create cs splits
+    # cs train images is ood unlabeled pool for first cycle
+    cs_train_cities = get_cs_splits(orig_base_dir, "train")
+    cs_train_images = []
+    for city in cs_train_cities:
+        cs_train_images.extend([image for image in cs_images if city in image[0]])
+    # cs val images is ood test
+    cs_test_cities = get_cs_splits(orig_base_dir, "val")
+    cs_test_images = []
+    for city in cs_test_cities:
+        cs_test_images.extend([image for image in cs_images if city in image[0]])
+
+    gta_unlabeled_pool_indices = np.random.choice(
+        len(gta_images), size=len(cs_train_images), replace=False
+    )
+    # gta unlabeled pool is id unlabeled pool
+    gta_unlabeled_pool_images = [
+        image
+        for index, image in enumerate(gta_images)
+        if index in gta_unlabeled_pool_indices
+    ]
+    gta_train_test_images = [
+        image
+        for index, image in enumerate(gta_images)
+        if index not in gta_unlabeled_pool_indices
+    ]
+
+    num_test = int(0.25 * len(gta_train_test_images))
+    gta_test_indices = np.random.choice(
+        len(gta_train_test_images), size=num_test, replace=False
+    )
+    # id test images
+    gta_test_images = [
+        image
+        for index, image in enumerate(gta_train_test_images)
+        if index in gta_test_indices
+    ]
+    # train / val images
+    gta_train_val_images = [
+        image
+        for index, image in enumerate(gta_train_test_images)
+        if index not in gta_test_indices
+    ]
+
+    splits = []
+    kfold = KFold(n_splits=n_splits, shuffle=True, random_state=seed)
+    # create fold dictionary and append it to splits
+    for i, (train_idx, val_idx) in enumerate(kfold.split(gta_train_val_images)):
+        gta_train_images = [
+            image
+            for index, image in enumerate(gta_train_val_images)
+            if index in train_idx
+        ]
+        gta_val_images = [
+            image
+            for index, image in enumerate(gta_train_val_images)
+            if index in val_idx
+        ]
+        split_dict = dict()
+        split_dict["train"] = gta_train_images
+        split_dict["val"] = gta_val_images
+        split_dict["id_test"] = gta_test_images
+        split_dict["ood_test"] = cs_test_images
+        split_dict["id_unlabeled_pool"] = gta_unlabeled_pool_images
+        split_dict["ood_unlabeled_pool"] = cs_train_images
+        splits.append(split_dict)
+
+    with open(splits_path, "wb") as f:
+        pickle.dump(splits, f)
+
+
+def main(args: Namespace):
+    pl.seed_everything(123)
+    dataset_path = Path(args.dataset_path)
+    if args.original_dataset_path is None:
+        original_dataset_path = dataset_path
+    else:
+        original_dataset_path = Path(args.original_dataset_path)
+    if args.splits_path is not None:
+        splits_path = Path(args.splits_path)
+        if not str(splits_path).endswith(".pkl"):
+            splits_path = splits_path / "splits.pkl"
+    else:
+        splits_path = dataset_path / "splits" / "firstCycle" / "splits.pkl"
+    os.makedirs(splits_path.parent, exist_ok=True)
+    create_splits(
+        base_dir=dataset_path,
+        orig_base_dir=original_dataset_path,
+        splits_path=splits_path,
+        seed=123,
+    )
+
+
+if __name__ == "__main__":
+    cli_args = main_cli()
+    main(args=cli_args)

--- a/datasets/gta_cityscapes/preprocess_gta_cityscapes_small.py
+++ b/datasets/gta_cityscapes/preprocess_gta_cityscapes_small.py
@@ -1,0 +1,193 @@
+import os.path
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+
+import numpy as np
+from batchgenerators.utilities.file_and_folder_operations import subfiles
+
+import albumentations as A
+import cv2
+from tqdm import tqdm
+
+import sys
+
+sys.path.append("../../")
+import uncertainty_modeling.data.cityscapes_labels as cs_labels
+
+
+def main_cli():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--dataset_path",
+        "-d",
+        type=str,
+        help="Path to the original dataset.",
+        required=True,
+    )
+    parser.add_argument(
+        "--save_path",
+        "-s",
+        type=str,
+        help="Root path to save the preprocessed files (will create subfolder preprocessed)."
+        "If not specified, uses the folder with the original data and creates a preprocessed subfolder "
+        "(recommended)",
+        default=None,
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        help="Which dataset to preprocess, i.e. which dataset is stored in dataset_path."
+        "Either 'cityscapes' or 'gta'",
+        required=True,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def preprocess_dataset(dataset_dir: Path, save_dir: Path, dataset: str) -> None:
+    output_dir_images = save_dir / "preprocessed" / "images"
+    output_dir_labels = save_dir / "preprocessed" / "labels"
+    # save the color maps of the labels
+    output_dir_labels_color = output_dir_labels / "vis"
+    output_dir_image_vis = output_dir_images / "vis"
+
+    os.makedirs(output_dir_images, exist_ok=True)
+    os.makedirs(output_dir_image_vis, exist_ok=True)
+    os.makedirs(output_dir_labels, exist_ok=True)
+    os.makedirs(output_dir_labels_color, exist_ok=True)
+
+    if dataset == "cityscapes":
+        splits = ["train", "val"]
+        images_base_path = dataset_dir / "images" / "leftImg8bit"
+        labels_base_path = dataset_dir / "labels" / "gtFine"
+        image_dirs = []
+        label_dirs = []
+        for split in splits:
+            splits_image_dir = images_base_path / split
+            splits_label_dir = labels_base_path / split
+            for city in os.listdir(splits_image_dir):
+                image_dir = splits_image_dir / city
+                label_dir = splits_label_dir / city
+                if image_dir.is_dir():
+                    image_dirs.append(image_dir)
+                    label_dirs.append(label_dir)
+        image_dirs = sorted(image_dirs)
+        label_dirs = sorted(label_dirs)
+    else:
+        image_dirs = [dataset_dir / "images"]
+        label_dirs = [dataset_dir / "labels"]
+
+    num_diff_res = 0
+    for image_dir, label_dir in zip(image_dirs, label_dirs):
+        png_images = subfiles(image_dir, suffix=".png", join=False)
+        # avoid mac ._ prefixed images
+        png_images = [image for image in png_images if not image.startswith(".")]
+
+        # define transformations
+        crop_transform = A.Compose(
+            [
+                A.CenterCrop(height=1024, width=1912, always_apply=True),
+            ]
+        )
+
+        for image_name in tqdm(png_images):
+            if dataset == "cityscapes":
+                image_id = image_name.split("_leftImg8bit")[0]
+            else:
+                image_id = image_name.split(".")[0]
+            image_np_save_path = output_dir_images / f"{image_id}.npy"
+            image_png_save_path = output_dir_image_vis / f"{image_id}.png"
+            mask_np_save_path = output_dir_labels / f"{image_id}.npy"
+            mask_png_save_path = output_dir_labels_color / f"{image_id}.png"
+
+            if (
+                image_np_save_path.is_file()
+                and image_png_save_path.is_file()
+                and mask_np_save_path.is_file()
+                and mask_png_save_path.is_file()
+            ):
+                continue
+            if image_name == "15188.png" or image_name == "17705.png":
+                continue
+
+            image_path = image_dir / image_name
+            if dataset == "cityscapes":
+                label_path = label_dir / f"{image_id}_gtFine_labelIds.png"
+            else:
+                label_path = label_dir / image_name
+
+            image = cv2.imread(str(image_path), -1)
+            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            mask_transform = cv2.imread(str(label_path), -1)
+
+            if image.shape[:2] != mask_transform.shape[:2]:
+                num_diff_res += 1
+                print(f"Different resolutions between image and mask for {image_name}!")
+                continue
+
+            # apply albumentations transforms
+            transformed = crop_transform(image=image, mask=mask_transform)
+            image = transformed["image"].astype(np.uint8)
+
+            # rescale image and mask to 128x256 resolution using different interpolation schemes
+            image = cv2.resize(
+                image, (256, 128), interpolation=cv2.INTER_LINEAR
+            )
+            if dataset == "cityscapes":
+                mask_labels = transformed["mask"].astype(np.uint8)
+                mask_labels = cv2.resize(
+                    mask_labels,
+                    (256, 128),
+                    interpolation=cv2.INTER_NEAREST,
+                )
+
+                # ignore labels that are not evaluated
+                mask_train_indices = mask_labels.copy()
+                for k, v in cs_labels.id2trainId.items():
+                    mask_train_indices[mask_labels == k] = v
+
+                # transform the labels to color map for visualization
+                mask_color = np.zeros((*mask_train_indices.shape, 3), dtype=np.uint8)
+                for k, v in cs_labels.trainId2color.items():
+                    mask_color[mask_train_indices == k] = np.array(v)
+            else:
+                mask_color = transformed["mask"].astype(np.uint8)
+                mask_color = cv2.cvtColor(mask_color, cv2.COLOR_BGR2RGB)
+                mask_color = cv2.resize(
+                    mask_color,
+                    (256, 128),
+                    interpolation=cv2.INTER_NEAREST,
+                )
+
+                # transform the color mask to actual labels, use the 19 training labels here
+                mask_train_indices = np.apply_along_axis(
+                    lambda x: cs_labels.color2trainId.get(tuple(x), 128),
+                    axis=-1,
+                    arr=mask_color,
+                )
+                assert (
+                    128 not in mask_train_indices
+                ), f"Unknown color value in mask for image {image_name}!"
+
+            np.save(image_np_save_path, image)
+            image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+            mask_color = cv2.cvtColor(mask_color, cv2.COLOR_RGB2BGR)
+
+            cv2.imwrite(str(image_png_save_path), image)
+            np.save(mask_np_save_path, mask_train_indices)
+            cv2.imwrite(str(mask_png_save_path), mask_color)
+
+
+def main(args: Namespace):
+    dataset_path = Path(args.dataset_path)
+    if args.save_path is not None:
+        save_path = Path(args.save_path)
+    else:
+        save_path = dataset_path
+    dataset = args.dataset
+    preprocess_dataset(dataset_dir=dataset_path, save_dir=save_path, dataset=dataset)
+
+
+if __name__ == "__main__":
+    cli_args = main_cli()
+    main(cli_args)

--- a/evaluation/configs/datasets/gta_small.yaml
+++ b/evaluation/configs/datasets/gta_small.yaml
@@ -1,0 +1,57 @@
+#@package _global_
+defaults:
+  - /../../uncertainty_modeling/configs/datamodule/gta_small_torch_config@GTA.datamodule_config
+  - /../../uncertainty_modeling/configs/data_augmentations/tta_small_augmentations
+  - _self_
+
+AUGMENTATIONS:
+  TEST:
+    - Compose:
+        transforms:
+          - Normalize:
+              mean: ${AUGMENTATIONS.mean}
+              std: ${AUGMENTATIONS.std}
+          - StochasticLabelSwitches:
+              always_apply: True
+              p: 1.0
+              n_reference_samples: ${GTA.n_reference_segs}
+          - ToTensorV2:
+
+GTA:
+  iter_params:
+    pred_model: [ "Softmax", "Dropout-Final", "Ensemble", "TTA", "SSN" ]
+    seed: [ "123", "124", "125" ]
+  fold: 0
+  rank: 10
+  n_classes: 19
+  image_ending: ".png"
+  unc_ending: ".tif"
+  datamodule_config:
+    data_input_dir: "/nvme/GTA_small"
+  n_reference_segs: 5
+  pred_seg_loading:
+    _target_: evaluation.utils.gta.pred_seg_loading
+  gt_unc_map_loading:
+    _target_: evaluation.utils.gta.gt_unc_map
+
+  prediction_models:
+    Softmax:
+      naming_scheme_version: "fold{fold}_seed{seed}"
+      unc_types: [ "predictive_uncertainty" ]
+      aggregations: [ "image_level", "patch_level" ]
+    Dropout-Final:
+      naming_scheme_version: "fold{fold}_seed{seed}"
+      unc_types: [ "predictive_uncertainty", "aleatoric_uncertainty", "epistemic_uncertainty" ]
+      aggregations: [ "image_level", "patch_level" ]
+    Ensemble:
+      naming_scheme_version: "fold{fold}_seed{seed}"
+      unc_types: [ "predictive_uncertainty", "aleatoric_uncertainty", "epistemic_uncertainty" ]
+      aggregations: [ "image_level", "patch_level" ]
+    TTA:
+      naming_scheme_version: "fold{fold}_seed{seed}"
+      unc_types: [ "predictive_uncertainty", "aleatoric_uncertainty", "epistemic_uncertainty" ]
+      aggregations: [ "image_level", "patch_level" ]
+    SSN:
+      naming_scheme_version: "rank{rank}_fold{fold}_seed{seed}"
+      unc_types: [ "predictive_uncertainty", "aleatoric_uncertainty", "epistemic_uncertainty" ]
+      aggregations: [ "image_level", "patch_level" ]

--- a/uncertainty_modeling/configs/data_augmentations/tta_small_augmentations.yaml
+++ b/uncertainty_modeling/configs/data_augmentations/tta_small_augmentations.yaml
@@ -1,0 +1,50 @@
+#@package _global_
+AUGMENTATIONS:
+  rotation_limit: 22.5
+  # scaling limit is offset by 1 in albumentations -> scaling between 0.8 and 1.2 here
+  scale_limit: [ -0.2, 0.2 ]
+  width: 256
+  height: 128
+  mean: [ 0.485, 0.456, 0.406 ]
+  std: [ 0.229, 0.224, 0.225 ]
+  border_mode: 0
+  mask_value: 255
+  TRAIN:
+    - Compose:
+        transforms:
+          - HorizontalFlip:
+              p: 0.5
+          - Rotate:
+              limit: ${AUGMENTATIONS.rotation_limit}
+              border_mode: ${AUGMENTATIONS.border_mode}
+              mask_value: ${AUGMENTATIONS.mask_value}
+          - RandomScale:
+              scale_limit: ${AUGMENTATIONS.scale_limit}
+              p: 1.0
+          - PadIfNeeded:
+              min_height: ${AUGMENTATIONS.height}
+              min_width: ${AUGMENTATIONS.width}
+              border_mode: ${AUGMENTATIONS.border_mode}
+              mask_value: ${AUGMENTATIONS.mask_value}
+          - RandomCrop:
+              height: ${AUGMENTATIONS.height}
+              width: ${AUGMENTATIONS.width}
+          - GaussNoise:
+          - Normalize:
+              mean: ${AUGMENTATIONS.mean}
+              std: ${AUGMENTATIONS.std}
+          - StochasticLabelSwitches:
+              always_apply: True
+              p: 1.0
+          - ToTensorV2:
+  VALIDATION:
+    - Compose:
+        transforms:
+          - Normalize:
+              mean: ${AUGMENTATIONS.mean}
+              std: ${AUGMENTATIONS.std}
+          - StochasticLabelSwitches:
+              always_apply: True
+              p: 1.0
+          - ToTensorV2:
+  TEST: ${AUGMENTATIONS.VALIDATION}

--- a/uncertainty_modeling/configs/datamodule/gta_small_torch_config.yaml
+++ b/uncertainty_modeling/configs/datamodule/gta_small_torch_config.yaml
@@ -1,0 +1,12 @@
+_target_: uncertainty_modeling.data.torch_dataloader.BaseDataModule   # Base Data Module
+num_classes: 24
+ignore_index: 255
+num_workers: 10
+batch_size: 6
+val_batch_size: 6
+data_fold_id: 0
+augmentations: ${AUGMENTATIONS}
+dataset:
+  _target_: uncertainty_modeling.data.cityscapes_dataset.Cityscapes_dataset
+  # splits_path: "/nvme/GTA_small/splits/firstCycle/splits.pkl"
+  splits_path: "/path/to/GTA_small/splits/firstCycle/splits.pkl"


### PR DESCRIPTION
## Summary
- add preprocessing script for 128x256 GTA/Cityscapes variant
- add split generation helper for the small dataset
- provide dataset and augmentation configs for new resolution
- wire up evaluation config for the small dataset

## Testing
- `pip install numpy albumentations hydra-core`
- `pip install torch torchvision torchaudio`
- `pip install torchmetrics`
- `PYTHONPATH=. pytest -q` *(fails: No module named 'uncertainty_modeling.data_carrier')*

------
https://chatgpt.com/codex/tasks/task_e_68bff791804083208266f0e5c55e5a16