### PR TITLE
Add 2D LIDC-IDRI slice processing and preprocessing

### DIFF
--- a/datasets/lidc-idri/save_cropped_nodules_2D.py
+++ b/datasets/lidc-idri/save_cropped_nodules_2D.py
@@ -1,0 +1,127 @@
+import os
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+import pylidc as pl
+import pylidc.utils
+from tqdm import tqdm
+
+
+def main_cli():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--save_path",
+        "-s",
+        type=str,
+        help="Path to the folder where the cropped nodules will be stored",
+        required=True,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def has_large_mask(nod):
+    """Checks if the consensus mask is larger than 64 voxels in any dimension."""
+    consensus_mask, _, _ = pylidc.utils.consensus(nod, clevel=0.1)
+    max_size_mask = max(consensus_mask.shape)
+    if max_size_mask > 64:
+        return True
+
+
+def append_metadata(metadata_nod, nod, first=False):
+    features = [
+        "subtlety",
+        "internal Structure",
+        "calcification",
+        "sphericity",
+        "margin",
+        "lobulation",
+        "spiculation",
+        "texture",
+        "malignancy",
+    ]
+    if first:
+        for feature in features:
+            metadata_nod[feature] = []
+    if nod is not None:
+        for feature in features:
+            metadata_nod[feature].append(getattr(nod, feature.replace(" ", "")))
+    else:
+        for feature in features:
+            metadata_nod[feature].append(None)
+
+
+def save_nodules(args: Namespace):
+    # Set up the paths to store the data
+    save_path = Path(args.save_path)
+    images_save_dir = save_path / "images"
+    labels_save_dir = save_path / "labels"
+    os.makedirs(save_path, exist_ok=True)
+    os.makedirs(images_save_dir, exist_ok=True)
+    os.makedirs(labels_save_dir, exist_ok=True)
+
+    scans = pl.query(pl.Scan)
+    all_metadata = []
+    global_idx = 0
+    for scan in tqdm(scans):
+        nods = scan.cluster_annotations()
+        for nod_idx, nod in enumerate(nods):
+            if has_large_mask(nod):
+                continue
+            metadata_nod = {}
+            masks = []
+            for ann_idx in range(4):
+                if ann_idx == 0:
+                    image_size = 64
+                    vol, mask, irp_pts = nod[ann_idx].uniform_cubic_resample(
+                        image_size - 1, return_irp_pts=True
+                    )
+                    metadata_nod["Patient ID"] = str(nod[0].scan.patient_id)
+                    metadata_nod["Scan ID"] = str(nod[0].scan.id).zfill(4)
+                    append_metadata(metadata_nod, nod[ann_idx], first=True)
+                if ann_idx < len(nod):
+                    mask = nod[ann_idx].uniform_cubic_resample(
+                        image_size - 1, resample_vol=False, irp_pts=irp_pts
+                    )
+                    annotation = nod[ann_idx]
+                else:
+                    mask = np.zeros([64, 64, 64])
+                    annotation = None
+                masks.append(mask)
+                if ann_idx > 0:
+                    append_metadata(metadata_nod, annotation)
+            # determine which slices to save (at least one rater positive)
+            positive_slices = [
+                s for s in range(vol.shape[2]) if any(m[:, :, s].any() for m in masks)
+            ]
+            for slice_idx in positive_slices:
+                image_slice = vol[:, :, slice_idx]
+                image_save_path = (
+                    images_save_dir
+                    / f"{str(nod[0].scan.id).zfill(4)}_{str(global_idx).zfill(3)}.npy"
+                )
+                np.save(image_save_path, image_slice)
+                seg_paths = []
+                for rater in range(4):
+                    label_slice = masks[rater][:, :, slice_idx]
+                    segmentation_save_path = (
+                        labels_save_dir
+                        / f"{str(nod[0].scan.id).zfill(4)}_{str(global_idx).zfill(3)}_{str(rater).zfill(2)}_mask.npy"
+                    )
+                    np.save(segmentation_save_path, label_slice.astype(np.intc))
+                    seg_paths.append(segmentation_save_path)
+                metadata_slice = metadata_nod.copy()
+                metadata_slice["Nodule Index"] = str(global_idx).zfill(3)
+                metadata_slice["Image Save Path"] = image_save_path
+                metadata_slice["Segmentation Save Paths"] = seg_paths
+                all_metadata.append(pd.Series(metadata_slice))
+                global_idx += 1
+    metadata = pd.DataFrame(all_metadata)
+    metadata.to_csv(save_path / "metadata.csv", index=False)
+
+
+if __name__ == "__main__":
+    cli_args = main_cli()
+    save_nodules(cli_args)

--- a/datasets/preprocess_datasets_2d.py
+++ b/datasets/preprocess_datasets_2d.py
@@ -1,0 +1,173 @@
+import os
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import List
+
+import numpy as np
+from batchgenerators.augmentations.utils import pad_nd_image
+from batchgenerators.utilities.file_and_folder_operations import subfiles
+
+
+def main_cli():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--dataset_path",
+        "-d",
+        type=str,
+        help="Root path to the original dataset with images and labels.",
+        required=True,
+    )
+    parser.add_argument(
+        "--save_path",
+        "-s",
+        type=str,
+        help="Root path to save the preprocessed files (will create subfolder preprocessed)."
+        "If not specified, uses the folder with the original data and creates a preprocessed subfolder "
+        "(recommended)",
+        default=None,
+    )
+    parser.add_argument(
+        "--num_raters",
+        "-r",
+        type=int,
+        help="Number of raters that labeled one image.",
+        required=True,
+    )
+    parser.add_argument(
+        "--image_dirs",
+        "-i",
+        type=str,
+        nargs="+",
+        help="Name of the directory in root_dir where the original images are located,""e.g. [imagesTr, imagesTs]. If None, assumes [images]",
+        default=None,
+    )
+    parser.add_argument(
+        "--label_dirs",
+        "-l",
+        type=str,
+        nargs="+",
+        help="Name of the directory in root_dir where the original labels are located,""e.g. [labelsTr, labelsTs]. If None, assumes [labels]. Has to match corresponding image_dirs.",
+        default=None,
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        help="Which dataset to preprocess, i.e. which dataset is stored in dataset_path.""Currently either 'toy' or 'lidc'",
+        default=None,
+    )
+    args = parser.parse_args()
+    return args
+
+
+def preprocess_dataset(
+    root_dir: Path,
+    save_path: Path,
+    num_raters: int,
+    image_dirs: List[str] = None,
+    label_dirs: List[str] = None,
+    dataset: str = None,
+    patch_size: int = 64,
+    patch_overlap: float = 1,
+) -> None:
+    """Preprocess the dataset, i.e. normalize the images (z-score normalization) and save
+
+    Args:
+        root_dir (Path): The root directory of the dataset
+        save_path (Path): Directory where to store the preprocessed dataset
+        num_raters (int): Number of raters that labeled one image
+        image_dirs (List[str]): Name of the directory in root_dir where the original images are located,
+                                e.g. [imagesTr, imagesTs]. If None, assumes [images]
+        label_dirs (List[str]): Name of the directory in root_dir where the original labels are located,
+                                e.g. [labelsTr, labelsTs]. If None, assumes [labels]. Has to match corresponding image_dirs.
+        dataset (str): Name of the dataset to preprocess
+        patch_size (int): Size of the patches used for training
+        patch_overlap (float): How much the patches overlap
+    """
+    if image_dirs is None:
+        image_dirs = ["images"]
+    if label_dirs is None:
+        label_dirs = ["labels"]
+    for image_dir_name, label_dir_name in zip(image_dirs, label_dirs):
+        image_dir = root_dir / image_dir_name
+        label_dir = root_dir / label_dir_name
+        output_dir_images = save_path / "preprocessed" / image_dir_name
+        output_dir_labels = save_path / "preprocessed" / label_dir_name
+
+        os.makedirs(output_dir_images, exist_ok=True)
+        os.makedirs(output_dir_labels, exist_ok=True)
+
+        npy_files = subfiles(image_dir, suffix=".npy", join=False)
+
+        all_images = []
+        all_labels = []
+        for f in npy_files:
+            image = np.load(os.path.join(image_dir, f))
+            all_images.append(image)
+            raters = []
+            for rater in range(num_raters):
+                if dataset == "lidc" or dataset == "lidc-idri":
+                    label_name = f.replace(
+                        ".npy", f"_{str(rater).zfill(2)}_mask.npy"
+                    )
+                else:
+                    label_name = f.replace(
+                        ".npy", f"_{str(rater).zfill(2)}.npy"
+                    )
+                if os.path.isfile(os.path.join(label_dir, label_name)):
+                    label = np.load(os.path.join(label_dir, label_name))
+                    raters.append(label)
+            all_labels.append(raters)
+
+        for image, label, f in zip(all_images, all_labels, npy_files):
+            image = (image - image.mean()) / (image.std() + 1e-8)
+            pad_size_x = image.shape[0] + (
+                image.shape[0] % int(patch_size * patch_overlap)
+            )
+            pad_size_y = image.shape[1] + (
+                image.shape[1] % int(patch_size * patch_overlap)
+            )
+            image = pad_nd_image(
+                image,
+                (pad_size_x, pad_size_y),
+                "constant",
+                kwargs={"constant_values": image.min()},
+            )
+            np.save(os.path.join(output_dir_images, f.split(".")[0] + ".npy"), image)
+            for rater in range(len(label)):
+                label_rater = pad_nd_image(
+                    label[rater],
+                    (pad_size_x, pad_size_y),
+                    "constant",
+                    kwargs={"constant_values": label[rater].min()},
+                )
+
+                if dataset == "lidc" or dataset == "lidc-idri":
+                    file_name = f"{f.split('.')[0]}_{str(rater).zfill(2)}_mask.npy"
+                else:
+                    file_name = f"{f.split('.')[0]}_{str(rater).zfill(2)}.npy"
+                np.save(output_dir_labels / file_name, label_rater)
+
+
+def main(args: Namespace):
+    dataset_path = Path(args.dataset_path)
+    if args.save_path is not None:
+        save_path = Path(args.save_path)
+    else:
+        save_path = dataset_path
+    image_dirs = args.image_dirs
+    label_dirs = args.label_dirs
+    dataset = args.dataset
+    num_raters = args.num_raters
+    preprocess_dataset(
+        root_dir=dataset_path,
+        save_path=save_path,
+        image_dirs=image_dirs,
+        label_dirs=label_dirs,
+        dataset=dataset,
+        num_raters=num_raters,
+    )
+
+
+if __name__ == "__main__":
+    cli_args = main_cli()
+    main(args=cli_args)


### PR DESCRIPTION
## Summary
- Add 2D version of LIDC-IDRI nodule cropping that stores individual slices and metadata.
- Introduce 2D preprocessing utility for normalized slice-based datasets.

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'uncertainty_modeling.data_carrier'; ImportError: cannot import name 'dice' from 'torchmetrics.functional')*


------
https://chatgpt.com/codex/tasks/task_e_68c148a0cd1c83208a04e6be7d112a0d